### PR TITLE
Improve UI and integrate free HuggingFace API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,4 @@
 JWT_SECRET=your_jwt_secret
 MONGO_URI=mongodb://localhost:27017/pdfsummary
-HUGGINGFACE_API_KEY=your_huggingface_key
+# Optional: Hugging Face token if you have one
+# HUGGINGFACE_API_KEY=your_huggingface_key

--- a/README.md
+++ b/README.md
@@ -5,4 +5,7 @@
 1. Copy `.env.example` to `.env` and set values.
 2. Run `docker-compose up --build` to start MongoDB, backend and frontend services.
 
+The Hugging Face API key is optional. Without it the app will use the free inference
+API for summarization.
+
 Frontend will be accessible on `http://localhost:3000` and backend on `http://localhost:5000`.

--- a/backend/routes/uploadRoutes.js
+++ b/backend/routes/uploadRoutes.js
@@ -13,11 +13,11 @@ router.post('/', auth, upload.single('file'), async (req, res) => {
     const data = await pdfParse(req.file.buffer);
     const text = data.text;
     const response = await axios.post(
-      'https://api-inference.huggingface.co/models/facebook/bart-large-cnn',
-      { inputs: text },
-      { headers: { Authorization: `Bearer ${process.env.HUGGINGFACE_API_KEY}` } }
+      'https://api-inference.huggingface.co/models/sshleifer/distilbart-cnn-12-6',
+      { inputs: text }
     );
-    const summaryText = response.data[0]?.summary_text || '';
+    const dataField = Array.isArray(response.data) ? response.data[0] : response.data;
+    const summaryText = dataField?.summary_text || '';
     const summary = new Summary({
       userId: req.user,
       text,

--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <title>PDF Summary App</title>
+    <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/public/styles.css
+++ b/frontend/public/styles.css
@@ -1,0 +1,35 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f2f2f2;
+  margin: 0;
+  padding: 0;
+}
+
+.container {
+  max-width: 400px;
+  margin: 50px auto;
+  background: #fff;
+  padding: 20px;
+  border-radius: 8px;
+  box-shadow: 0 2px 5px rgba(0, 0, 0, 0.1);
+}
+
+form input, form button {
+  width: 100%;
+  padding: 10px;
+  margin-top: 10px;
+}
+
+button {
+  cursor: pointer;
+  background-color: #007bff;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+}
+
+pre {
+  background: #f0f0f0;
+  padding: 10px;
+  white-space: pre-wrap;
+}

--- a/frontend/src/pages/Dashboard.js
+++ b/frontend/src/pages/Dashboard.js
@@ -19,10 +19,14 @@ export default function Dashboard({ token, onLogout }) {
   };
 
   return (
-    <div>
+    <div className="container">
       <button onClick={onLogout}>Logout</button>
       <form onSubmit={upload}>
-        <input type="file" accept="application/pdf" onChange={(e) => setFile(e.target.files[0])} />
+        <input
+          type="file"
+          accept="application/pdf"
+          onChange={(e) => setFile(e.target.files[0])}
+        />
         <button type="submit">Upload</button>
       </form>
       {summary && <pre>{summary}</pre>}

--- a/frontend/src/pages/Login.js
+++ b/frontend/src/pages/Login.js
@@ -12,11 +12,22 @@ export default function Login({ onSuccess }) {
   };
 
   return (
-    <form onSubmit={submit}>
+    <div className="container">
       <h2>Login</h2>
-      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="email" />
-      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="password" />
-      <button type="submit">Login</button>
-    </form>
+      <form onSubmit={submit}>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button type="submit">Login</button>
+      </form>
+    </div>
   );
 }

--- a/frontend/src/pages/Register.js
+++ b/frontend/src/pages/Register.js
@@ -12,11 +12,22 @@ export default function Register({ onSuccess }) {
   };
 
   return (
-    <form onSubmit={submit}>
+    <div className="container">
       <h2>Register</h2>
-      <input value={email} onChange={(e) => setEmail(e.target.value)} placeholder="email" />
-      <input type="password" value={password} onChange={(e) => setPassword(e.target.value)} placeholder="password" />
-      <button type="submit">Register</button>
-    </form>
+      <form onSubmit={submit}>
+        <input
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+        />
+        <button type="submit">Register</button>
+      </form>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- tweak env example to make Hugging Face token optional
- document optional token in README
- style pages with new `styles.css`
- add CSS link in `index.html`
- wrap login, register and dashboard pages in a container for better look
- use the free `distilbart-cnn-12-6` model without authentication

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686506d72e9c8333a918f9569c833876