### PR TITLE
Connect frontend to backend

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 JWT_SECRET=sss
 MONGO_URI=mongodb://localhost:27017/pdfsummary
 HUGGINGFACE_API_KEY=
+VITE_API_URL=http://localhost:5000

--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ JWT_SECRET=your_jwt_secret
 MONGO_URI=mongodb://localhost:27017/pdfsummary
 # Optional: Hugging Face token if you have one
 # HUGGINGFACE_API_KEY=your_huggingface_key
+VITE_API_URL=http://localhost:5000

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,7 +9,7 @@ import { analyzeDocument, simulateProgress } from './services/documentAnalyzer';
 import { AnalysisState } from './types';
 
 function App() {
-  const { user, login, logout, isLoading: authLoading } = useAuth();
+  const { user, token, login, logout, isLoading: authLoading } = useAuth();
   const [analysisState, setAnalysisState] = useState<AnalysisState>({
     isAnalyzing: false,
     progress: 0,
@@ -32,8 +32,10 @@ function App() {
         setAnalysisState(prev => ({ ...prev, progress }));
       });
 
-      // Analyze document
-      const analysis = await analyzeDocument(file);
+      if (!token) throw new Error('No auth token');
+
+      // Analyze document via backend
+      const analysis = await analyzeDocument(file, token);
       
       setAnalysisState(prev => ({
         ...prev,

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -3,44 +3,68 @@ import { User } from '../types';
 
 export const useAuth = () => {
   const [user, setUser] = useState<User | null>(null);
+  const [token, setToken] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
-    // Simulate checking for existing session
     const savedUser = localStorage.getItem('user');
-    if (savedUser) {
+    const savedToken = localStorage.getItem('token');
+    if (savedUser && savedToken) {
       setUser(JSON.parse(savedUser));
+      setToken(savedToken);
     }
     setIsLoading(false);
   }, []);
 
   const login = async (email: string, password: string): Promise<boolean> => {
     setIsLoading(true);
-    
-    // Simulate API call
-    await new Promise(resolve => setTimeout(resolve, 1500));
-    
-    // Simple validation for demo
-    if (email && password.length >= 6) {
+
+    try {
+      const response = await fetch(`${import.meta.env.VITE_API_URL}/api/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+
+      if (!response.ok) throw new Error('Login failed');
+
+      const data = await response.json();
+      const token = data.token as string;
+
+      const parseJwt = (t: string) => {
+        try {
+          const base64 = t.split('.')[1].replace(/-/g, '+').replace(/_/g, '/');
+          const json = atob(base64);
+          return JSON.parse(json);
+        } catch {
+          return null;
+        }
+      };
+      const decoded = parseJwt(token);
       const user: User = {
-        id: '1',
+        id: decoded?.id || '',
         email,
         name: email.split('@')[0]
       };
+
       setUser(user);
+      setToken(token);
       localStorage.setItem('user', JSON.stringify(user));
+      localStorage.setItem('token', token);
       setIsLoading(false);
       return true;
+    } catch {
+      setIsLoading(false);
+      return false;
     }
-    
-    setIsLoading(false);
-    return false;
   };
 
   const logout = () => {
     setUser(null);
+    setToken(null);
     localStorage.removeItem('user');
+    localStorage.removeItem('token');
   };
 
-  return { user, login, logout, isLoading };
+  return { user, token, login, logout, isLoading };
 };

--- a/frontend/src/services/documentAnalyzer.ts
+++ b/frontend/src/services/documentAnalyzer.ts
@@ -1,17 +1,34 @@
 import { DocumentAnalysis } from '../types';
 
-// Simulated LLM analysis with improved document type detection
-export const analyzeDocument = async (file: File): Promise<DocumentAnalysis> => {
-  return new Promise((resolve) => {
-    // Simulate API processing time
-    setTimeout(() => {
-      // Detect document type based on filename and generate appropriate analysis
-      const documentType = detectDocumentType(file.name);
-      const analysis: DocumentAnalysis = generateAnalysisByType(file, documentType);
-      
-      resolve(analysis);
-    }, 3000);
+// Analyse le document via l'API backend puis génère une structure enrichie
+export const analyzeDocument = async (
+  file: File,
+  token: string
+): Promise<DocumentAnalysis> => {
+  const formData = new FormData();
+  formData.append('file', file);
+
+  const response = await fetch(`${import.meta.env.VITE_API_URL}/api/upload`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+    },
+    body: formData,
   });
+
+  if (!response.ok) {
+    throw new Error('Analyse échouée');
+  }
+
+  const data = await response.json();
+
+  const documentType = detectDocumentType(file.name);
+  const analysis: DocumentAnalysis = generateAnalysisByType(file, documentType);
+
+  // Remplace le résumé généré par celui du backend
+  analysis.summary = data.summary;
+
+  return analysis;
 };
 
 const detectDocumentType = (fileName: string): string => {


### PR DESCRIPTION
## Summary
- add `VITE_API_URL` to example and default env files
- implement real login and token storage
- fetch summary from backend when analyzing documents
- use auth token in `App` when uploading a file

## Testing
- `npm run build` *(fails: vite not found)*
- `npm run start` in backend *(fails: cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68650adeb0a483339ab90722805f6777